### PR TITLE
git-bisect: remove the directory refs/bisect/ at cleanup

### DIFF
--- a/git-bisect.sh
+++ b/git-bisect.sh
@@ -451,6 +451,7 @@ bisect_clean_state() {
 	git update-ref -d --no-deref BISECT_HEAD &&
 	# clean up BISECT_START last
 	rm -f "$GIT_DIR/BISECT_START"
+	rm -rf "$GIT_DIR/refs/bisect"
 }
 
 bisect_replay () {


### PR DESCRIPTION
Currently the directory .git/refs/bisect/ is not removed when cleaning
up the bisection state.

Mentored-by: Lars Schneider <larsxschneider@gmail.com>
Mentored-by: Christian Couder <chriscool@tuxfamily.org>
Signed-off-by: Pranit Bauva <pranit.bauva@gmail.com>