### PR TITLE
Is expected rev

### DIFF
--- a/builtin/bisect--helper.c
+++ b/builtin/bisect--helper.c
@@ -3,8 +3,10 @@
 #include "parse-options.h"
 #include "bisect.h"
 #include "refs.h"
+#include "dir.h"
 
 static GIT_PATH_FUNC(git_path_bisect_write_terms, "BISECT_TERMS")
+static GIT_PATH_FUNC(git_path_bisect_expected_rev, "BISECT_EXPECTED_REV")
 
 static const char * const git_bisect_helper_usage[] = {
 	N_("git bisect--helper --next-all [--no-checkout]"),
@@ -76,6 +78,20 @@ static int write_terms(const char *bad, const char *good)
 	res = fprintf(fp, "%s\n%s\n", bad, good);
 	fclose(fp);
 	return (res < 0) ? -1 : 0;
+}
+
+static int is_expected_rev(const char *expected_hex)
+{
+	struct strbuf actual_hex = STRBUF_INIT;
+
+	if (!file_exists(git_path_bisect_expected_rev()))
+		return 0;
+
+	if (!strbuf_read_file(&actual_hex, git_path_bisect_expected_rev(), 0))
+		return 0;
+
+	strbuf_trim(&actual_hex);
+	return !strcmp(actual_hex.buf, expected_hex);
 }
 
 int cmd_bisect__helper(int argc, const char **argv, const char *prefix)

--- a/dir.c
+++ b/dir.c
@@ -2036,6 +2036,14 @@ int file_exists(const char *f)
 	return lstat(f, &sb) == 0;
 }
 
+ssize_t file_size(const char *filename)
+{
+	struct stat st;
+	if (stat(filename, &st) < 0)
+		return -1;
+	return xsize_t(st.st_size);
+}
+
 static int cmp_icase(char a, char b)
 {
 	if (a == b)

--- a/dir.h
+++ b/dir.h
@@ -248,6 +248,13 @@ extern void clear_exclude_list(struct exclude_list *el);
 extern void clear_directory(struct dir_struct *dir);
 extern int file_exists(const char *);
 
+/*
+ * Return the size of the file `filename`. It returns -1 if error
+ * occurred, 0 if file is empty and a positive number denoting the size
+ * of the file.
+ */
+extern ssize_t file_size(const char *);
+
 extern int is_inside_dir(const char *dir);
 extern int dir_inside_of(const char *subdir, const char *dir);
 

--- a/git-bisect.sh
+++ b/git-bisect.sh
@@ -238,22 +238,6 @@ bisect_write() {
 	test -n "$nolog" || echo "git bisect $state $rev" >>"$GIT_DIR/BISECT_LOG"
 }
 
-is_expected_rev() {
-	test -f "$GIT_DIR/BISECT_EXPECTED_REV" &&
-	test "$1" = $(cat "$GIT_DIR/BISECT_EXPECTED_REV")
-}
-
-check_expected_revs() {
-	for _rev in "$@"; do
-		if ! is_expected_rev "$_rev"
-		then
-			rm -f "$GIT_DIR/BISECT_ANCESTORS_OK"
-			rm -f "$GIT_DIR/BISECT_EXPECTED_REV"
-			return
-		fi
-	done
-}
-
 bisect_skip() {
 	all=''
 	for arg in "$@"
@@ -280,7 +264,7 @@ bisect_state() {
 		rev=$(git rev-parse --verify $(bisect_head)) ||
 			die "$(gettext "Bad rev input: $(bisect_head)")"
 		bisect_write "$state" "$rev"
-		check_expected_revs "$rev" ;;
+		git bisect--helper --check-expected-revs "$rev" ;;
 	2,"$TERM_BAD"|*,"$TERM_GOOD"|*,skip)
 		shift
 		hash_list=''
@@ -294,7 +278,7 @@ bisect_state() {
 		do
 			bisect_write "$state" "$rev"
 		done
-		check_expected_revs $hash_list ;;
+		git bisect--helper --check-expected-revs $hash_list ;;
 	*,"$TERM_BAD")
 		die "$(eval_gettext "'git bisect \$TERM_BAD' can take only one argument.")" ;;
 	*)


### PR DESCRIPTION
I have converted is_expected_rev() and check_expected_revs(). The current problem is that get_sha1(".git/BISECT_EXPECTED_REV") is not really working as I expect it too. I tried a lot of variants like get_sha1("BISECT_EXPECTED_REV") and read_ref(git_path_bisect_expected_rev()) but something seems missing. I intend to finish it tomorrow and then get back on bisect-clean-state.